### PR TITLE
small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env:
         - PYTHON_VERSION=3.8
         - CONDA_PLATFORM=Linux-x86_64
-
+        - SKIP_TESTS_NOMPI=yes
 
     - os: osx
       env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pymeep" %}
 {% set version = "1.15.1.dev" %}
-{% set buildnumber = 24 %}
+{% set buildnumber = 25 %}
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
 {% if mpi == "nompi" %}
@@ -81,8 +81,6 @@ requirements:
     - autograd
 
 test:
-  requires:
-    - parallel
   imports:
     - meep
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - python
     - libctl >=4.5
-    - harminv
+    - harminv 1.4.1
     - mpb >=1.10.0 {{ mpi_prefix }}_*
     - gsl
     - hdf5 1.10.5 {{ mpi_prefix }}_*
@@ -66,7 +66,7 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - python
     - libctl >=4.5
-    - harminv
+    - harminv 1.4.1
     - mpb >=1.10.0 {{ mpi_prefix }}_*
     - {{ pin_compatible('numpy') }}
     - hdf5 * {{ mpi_prefix }}_*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - python
     - libctl >=4.5
-    - harminv 1.4.1
+    - harminv
     - mpb >=1.10.0 {{ mpi_prefix }}_*
     - gsl
     - hdf5 1.10.5 {{ mpi_prefix }}_*
@@ -66,7 +66,7 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - python
     - libctl >=4.5
-    - harminv 1.4.1
+    - harminv
     - mpb >=1.10.0 {{ mpi_prefix }}_*
     - {{ pin_compatible('numpy') }}
     - hdf5 * {{ mpi_prefix }}_*

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -26,11 +26,9 @@ else
     # Mac builds are over the 50 minute time limit on Travis. Skip the serial
     # tests until we find a way to speed things up
     if [[ $(uname) == Linux ]]; then
-        export OPENBLAS_NUM_THREADS=1
-        export OMP_NUM_THREADS=1
         for t in $(find python/tests -name "*.py" | sed /mpb/d); do
             echo "Running $(basename $t)"
-            $PYTHON $t
+            OPENBLAS_NUM_THREADS=1 $PYTHON $t
         done
     else
         echo "Skipping NOMPI tests on OSX."


### PR DESCRIPTION
`python/tests/ring.py` is failing on Travis after #16 was merged today. This failing test uses Harminv which has a BLAS/LAPACK dependency. Rather than setting `export OPENBLAS_NUM_THREADS=1` before calling Python, this PR sets this environment variable during the call to Python.